### PR TITLE
Simplify README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,3 @@
-# Personal Site of Michael Wang
+# michael.wang
 
-The repository for [michael.wang](https://michael.wang).
-
-- `npm start` — This will spawn a development server with a default port of `1234`.
-- `npm run build` — This will output a production build in the `dist` directory.
-
-## Custom port
-
-You can use the `-p` flag to specify a port for development. To do this, you can either run `npm start` with an additional flag:
-
-```
-npm start -- -p 3000
-```
-
-Or edit the `start` script directly:
-
-```
-parcel index.html -p 3000
-```
-
-## Adding styles
-
-You can use CSS files with simple ES2015 `import` statements in your Javascript:
-
-```js
-import "./index.css";
-```
-
-## Babel transforms
-
-The Babel preset [babel-preset-nano-react-app](https://github.com/adrianmcli/babel-preset-nano-react-app) and a small amount of configuration is used to support the same transforms that Create React App supports.
-
-The Babel configuration lives inside `package.json` and will override an external `.babelrc` file, so if you want to use `.babelrc` remember to delete the `babel` property inside `package.json`.
-
-Thank you!
+Source for [michael.wang](https://michael.wang).


### PR DESCRIPTION
## Summary
Streamlined the README.md to remove verbose setup instructions and implementation details, keeping only essential information about the project.

## Changes
- Simplified the title from "Personal Site of Michael Wang" to "michael.wang"
- Removed detailed setup instructions (`npm start`, `npm run build`, custom port configuration)
- Removed documentation about CSS imports, Babel transforms, and babel-preset-nano-react-app configuration
- Condensed the description to a single line pointing to the live site

## Rationale
The README now serves as a minimal landing page for the repository, with setup and development details likely moved to other documentation or assumed to be discoverable through standard tooling. This reduces maintenance burden and keeps the README focused on what the project is rather than how to develop it.

https://claude.ai/code/session_01QC8s1fSjcWshfGjnvehsPG